### PR TITLE
Ignore neighbours max when calculating unlockables

### DIFF
--- a/CookieClicker/Horticookie.js
+++ b/CookieClicker/Horticookie.js
@@ -810,9 +810,11 @@ Horticookie.launch = function(){
 			
 			if(mut.type == Horticookie.recipeCodes.NORMAL){
 				for(var j = 0; j < mut.neighsM.length; j++){
+					if(mut.neighsM[j].isMax) continue;
 					if(!M.plants[mut.neighsM[j].plant].unlocked) unlockable = false;
 				}
 				for(var j = 0; j < mut.neighs.length; j++){
+					if(mut.neighs[j].isMax) continue;
 					if(!M.plants[mut.neighs[j].plant].unlocked) unlockable = false;
 				}
 				

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# klattmose.github.io
+## Welcome to GitHub Pages
+
+You can use the [editor on GitHub](https://github.com/snnw/klattmose.github.io/edit/unlockables-fix/README.md) to maintain and preview the content for your website in Markdown files.
+
+Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
+
+### Markdown
+
+Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
+
+```markdown
+Syntax highlighted code block
+
+# Header 1
+## Header 2
+### Header 3
+
+- Bulleted
+- List
+
+1. Numbered
+2. List
+
+**Bold** and _Italic_ and `Code` text
+
+[Link](url) and ![Image](src)
+```
+
+For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
+
+### Jekyll Themes
+
+Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/snnw/klattmose.github.io/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
+
+### Support or Contact
+
+Having trouble with Pages? Check out our [documentation](https://docs.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal


### PR DESCRIPTION
Fixes that white mildew could never be unlocked because white mildew appears as an isMax neighbour